### PR TITLE
[FIX] Accounting/Invoice/all: allow to pass params

### DIFF
--- a/chift/models/consumers/accounting/__init__.py
+++ b/chift/models/consumers/accounting/__init__.py
@@ -93,9 +93,9 @@ class Invoice(
     chift_model: ClassVar = "invoices"
     model = InvoiceAccountingModel
 
-    def all(self, invoice_type, limit=None, client=None):
+    def all(self, invoice_type, **kwargs):
         self.extra_path = f"type/{invoice_type}"
-        return super().all(limit=limit, client=client)
+        return super().all(**kwargs)
 
 
 # deprecated


### PR DESCRIPTION
The override of the pagination mixin failed to take the params parameter.

Passing kwargs makes sure the override lets all parameters through, otherwise you need to make sure all named parameters are duplicated in the signature.