### PR TITLE
feat(client): add string repr to ChiftClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.2 - 2025-06-24
+* add string repr to ChiftClient
+
 ## 0.3.1 - 2025-06-22
 * make sure pagination stops if list of items is empty
 

--- a/chift/api/client.py
+++ b/chift/api/client.py
@@ -111,6 +111,24 @@ class ChiftClient:
         self.max_retries = kwargs.get("max_retries")
         self._start_session()
 
+    def __repr__(self) -> str:
+        client_secret = (
+            self.client_secret[:2]
+            + ("*" * (len(self.client_secret) - 4))
+            + self.client_secret[-2:]
+            if self.client_secret
+            else ""
+        )
+        return (
+            f"{self.__class__.__name__}("
+            f"consumer_id={self.consumer_id},"
+            f"client_id={self.client_id},"
+            f"client_secret={client_secret},"
+            f"env_id={self.env_id},"
+            f"url_base={self.url_base}"
+            ")"
+        )
+
     def _start_session(self):
         self.ignored_error_codes = []
         if self.test_client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chift"
-version = "0.3.1"
+version = "0.3.2"
 description = "Chift API client"
 authors = ["Henry Hertoghe <henry.hertoghe@chift.eu>"]
 readme = "README.md"


### PR DESCRIPTION
I think this should be helpful in debugging issues seen in Sentry.

```python
print(ChiftClient(consumer_id=uuid.uuid4(),client_id=uuid.uuid4(),client_secret="MySecret"))
```

Previously:
`<chift.api.client.ChiftClient object at 0x7f9584dd4050>`

Now:
`ChiftClient(consumer_id=2f7f26a9-aaaf-4a04-ad54-8ae87c8a9495,client_id=836c6b2a-0812-4703-b8ad-3ad863ff117e,client_secret=My****et,env_id=None,url_base=https://api.chift.eu)`