### PR TITLE
feat(client): support datalayer via x-chift-datalayer header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.7 - 2026-07-10
+- client: add `datalayer` parameter on request methods to send the `x-chift-datalayer` header
+
 ## 0.6.6 - 2026-06-30
 - pms: add optional `is_company` field to the `PMSCustomerItem` model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.6.7 - 2026-07-10
-- client: add `datalayer` parameter on request methods to send the `x-chift-datalayer` header
+- client: add `datalayer` parameter on request methods to send the `x-chift-datalayer` header. Supports both modes: `datalayer=True` (`"true"`) and `datalayer="if_available"`
 
 ## 0.6.6 - 2026-06-30
 - pms: add optional `is_company` field to the `PMSCustomerItem` model

--- a/chift/api/client.py
+++ b/chift/api/client.py
@@ -2,12 +2,19 @@ import base64
 import http.client as httplib
 import json
 from datetime import datetime
+from typing import Literal, Union
 
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 from chift.api import exceptions
+
+# Accepted values for the `datalayer` parameter, mapping to the `x-chift-datalayer` header:
+#   False / None    -> header omitted (live connector, "classic" mode)
+#   True            -> "true"         (require the datalayer, error if it can't serve)
+#   "if_available"  -> "if_available" (use the datalayer when available, else fall back to classic)
+DatalayerMode = Union[bool, Literal["if_available"]]
 
 
 class ChiftAuth(requests.auth.AuthBase):
@@ -169,7 +176,9 @@ class ChiftClient:
             headers["x-chift-raw-data"] = "true"
 
         if self.datalayer:
-            headers["x-chift-datalayer"] = "true"
+            headers["x-chift-datalayer"] = (
+                self.datalayer if isinstance(self.datalayer, str) else "true"
+            )
 
         if self.client_request_id:
             headers["x-chift-client-requestid"] = self.client_request_id

--- a/chift/api/client.py
+++ b/chift/api/client.py
@@ -68,6 +68,7 @@ class ChiftClient:
     consumer_id = None
     connection_id = None
     raw_data = None
+    datalayer = None
     client_request_id = None
     related_chain_execution_id = None
     sync_id = None
@@ -167,6 +168,9 @@ class ChiftClient:
         if self.raw_data:
             headers["x-chift-raw-data"] = "true"
 
+        if self.datalayer:
+            headers["x-chift-datalayer"] = "true"
+
         if self.client_request_id:
             headers["x-chift-client-requestid"] = self.client_request_id
 
@@ -197,9 +201,10 @@ class ChiftClient:
                 f"After {self.max_retries} retries, the request failed."
             )
         finally:
-            # reset client_request_id and raw_data
+            # reset client_request_id, raw_data and datalayer
             self.client_request_id = None
             self.raw_data = None
+            self.datalayer = None
 
         if req.status_code == httplib.UNAUTHORIZED:
             try:

--- a/chift/api/mixins.py
+++ b/chift/api/mixins.py
@@ -1,6 +1,6 @@
 from typing import Any, Generator, Generic, Literal, TypeVar, overload
 
-from chift.api.client import ChiftClient
+from chift.api.client import ChiftClient, DatalayerMode
 from chift.openapi.models import ObjectWithRawData
 
 T = TypeVar("T")
@@ -57,7 +57,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         raw_data: Literal[False] = False,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> T: ...
 
     @overload
@@ -68,7 +68,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         raw_data: Literal[False] = False,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> dict: ...
 
     @overload
@@ -79,7 +79,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         raw_data: Literal[True] = True,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> ObjectWithRawData[T]: ...
 
     @overload
@@ -90,7 +90,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         raw_data: Literal[True] = True,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> dict: ...
 
     def get(
@@ -137,7 +137,7 @@ class CreateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         client_request_id=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> T: ...
 
     @overload
@@ -148,7 +148,7 @@ class CreateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         client_request_id=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> dict: ...
 
     # we have a few post routes which are used as get (e.g. chart-of-accounts/balance)
@@ -160,7 +160,7 @@ class CreateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         client_request_id=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> list[T]: ...
 
     def create(
@@ -242,7 +242,7 @@ class UpdateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         client_request_id=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> T: ...
 
     @overload
@@ -254,7 +254,7 @@ class UpdateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         client_request_id=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> dict: ...
 
     def update(
@@ -337,7 +337,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         map_model: Literal[True] = True,
         limit=None,
         raw_data: Literal[False] = False,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> list[T]: ...
 
     @overload
@@ -348,7 +348,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         map_model: Literal[False] = False,
         limit=None,
         raw_data: Literal[False] = False,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> list[dict]: ...
 
     @overload
@@ -359,7 +359,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         map_model=False,
         limit=False,
         raw_data: Literal[True] = True,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> dict: ...
 
     def all(
@@ -394,7 +394,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         client=None,
         map_model: Literal[True] = True,
         limit=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> Generator[T, Any, None]: ...
 
     @overload
@@ -404,7 +404,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         client=None,
         map_model: Literal[False] = False,
         limit=None,
-        datalayer: bool = False,
+        datalayer: DatalayerMode = False,
     ) -> Generator[dict, Any, None]: ...
 
     def iter_all(

--- a/chift/api/mixins.py
+++ b/chift/api/mixins.py
@@ -23,12 +23,20 @@ class BaseMixin(object):
 
 
 class DeleteMixin(BaseMixin, Generic[T]):
-    def delete(self, chift_id, client=None, params=None, client_request_id=None) -> T:
+    def delete(
+        self,
+        chift_id,
+        client=None,
+        params=None,
+        client_request_id=None,
+        datalayer=False,
+    ) -> T:
         if not client:
             client = ChiftClient()
         client.consumer_id = self.consumer_id
         client.connection_id = self.connection_id
         client.raw_data = False
+        client.datalayer = datalayer
         client.client_request_id = client_request_id
 
         return client.delete_one(
@@ -49,6 +57,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         raw_data: Literal[False] = False,
+        datalayer: bool = False,
     ) -> T: ...
 
     @overload
@@ -59,6 +68,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         raw_data: Literal[False] = False,
+        datalayer: bool = False,
     ) -> dict: ...
 
     @overload
@@ -69,6 +79,7 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         raw_data: Literal[True] = True,
+        datalayer: bool = False,
     ) -> ObjectWithRawData[T]: ...
 
     @overload
@@ -79,16 +90,24 @@ class ReadMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         raw_data: Literal[True] = True,
+        datalayer: bool = False,
     ) -> dict: ...
 
     def get(
-        self, chift_id, client=None, params=None, map_model=True, raw_data=False
+        self,
+        chift_id,
+        client=None,
+        params=None,
+        map_model=True,
+        raw_data=False,
+        datalayer=False,
     ) -> T | dict | ObjectWithRawData[T]:
         if not client:
             client = ChiftClient()
         client.consumer_id = self.consumer_id
         client.connection_id = self.connection_id
         client.raw_data = raw_data
+        client.datalayer = datalayer
         client.client_request_id = None
 
         json_data = client.get_one(
@@ -118,6 +137,7 @@ class CreateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         client_request_id=None,
+        datalayer: bool = False,
     ) -> T: ...
 
     @overload
@@ -128,6 +148,7 @@ class CreateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         client_request_id=None,
+        datalayer: bool = False,
     ) -> dict: ...
 
     # we have a few post routes which are used as get (e.g. chart-of-accounts/balance)
@@ -139,16 +160,24 @@ class CreateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         client_request_id=None,
+        datalayer: bool = False,
     ) -> list[T]: ...
 
     def create(
-        self, data, client=None, params=None, map_model=True, client_request_id=None
+        self,
+        data,
+        client=None,
+        params=None,
+        map_model=True,
+        client_request_id=None,
+        datalayer=False,
     ) -> T | dict | list[T]:
         if not client:
             client = ChiftClient()
         client.consumer_id = self.consumer_id
         client.connection_id = self.connection_id
         client.raw_data = False
+        client.datalayer = datalayer
         client.client_request_id = client_request_id
 
         json_data = client.post_one(
@@ -184,6 +213,8 @@ class CreateMixin(BaseMixin, Generic[T]):
 
                 if json_data.get("items") and count < total:
                     page += 1
+                    # make_request resets datalayer after each call, re-apply it
+                    client.datalayer = datalayer
                     json_data = client.post_one(
                         self.chift_vertical,
                         self.chift_model_create,
@@ -211,6 +242,7 @@ class UpdateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[True] = True,
         client_request_id=None,
+        datalayer: bool = False,
     ) -> T: ...
 
     @overload
@@ -222,6 +254,7 @@ class UpdateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model: Literal[False] = False,
         client_request_id=None,
+        datalayer: bool = False,
     ) -> dict: ...
 
     def update(
@@ -232,12 +265,14 @@ class UpdateMixin(BaseMixin, Generic[T]):
         params=None,
         map_model=True,
         client_request_id=None,
+        datalayer=False,
     ) -> T | dict:
         if not client:
             client = ChiftClient()
         client.consumer_id = self.consumer_id
         client.connection_id = self.connection_id
         client.raw_data = False
+        client.datalayer = datalayer
         client.client_request_id = client_request_id
 
         json_data = client.update_one(
@@ -259,6 +294,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         client=None,
         limit=None,
         raw_data=False,
+        datalayer=False,
     ) -> Generator[dict, Any, None]:
         if not client:
             client = ChiftClient()
@@ -276,6 +312,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
             client.consumer_id = self.consumer_id
             client.connection_id = self.connection_id
             client.raw_data = raw_data
+            client.datalayer = datalayer
             client.client_request_id = None
             json_data = client.get_all(
                 self.chift_vertical,
@@ -300,6 +337,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         map_model: Literal[True] = True,
         limit=None,
         raw_data: Literal[False] = False,
+        datalayer: bool = False,
     ) -> list[T]: ...
 
     @overload
@@ -310,6 +348,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         map_model: Literal[False] = False,
         limit=None,
         raw_data: Literal[False] = False,
+        datalayer: bool = False,
     ) -> list[dict]: ...
 
     @overload
@@ -320,10 +359,17 @@ class PaginationMixin(BaseMixin, Generic[T]):
         map_model=False,
         limit=False,
         raw_data: Literal[True] = True,
+        datalayer: bool = False,
     ) -> dict: ...
 
     def all(
-        self, params=None, client=None, map_model=True, limit=None, raw_data=False
+        self,
+        params=None,
+        client=None,
+        map_model=True,
+        limit=None,
+        raw_data=False,
+        datalayer=False,
     ) -> list[T | dict] | dict:
         all_items = []
         for page in self.__iter_page(
@@ -331,6 +377,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
             client=client,
             limit=limit,
             raw_data=raw_data,
+            datalayer=datalayer,
         ):
             if raw_data:
                 return page.get("raw_data") or {}
@@ -347,6 +394,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         client=None,
         map_model: Literal[True] = True,
         limit=None,
+        datalayer: bool = False,
     ) -> Generator[T, Any, None]: ...
 
     @overload
@@ -356,6 +404,7 @@ class PaginationMixin(BaseMixin, Generic[T]):
         client=None,
         map_model: Literal[False] = False,
         limit=None,
+        datalayer: bool = False,
     ) -> Generator[dict, Any, None]: ...
 
     def iter_all(
@@ -364,12 +413,14 @@ class PaginationMixin(BaseMixin, Generic[T]):
         client=None,
         map_model=True,
         limit=None,
+        datalayer=False,
     ) -> Generator[T | dict, Any, None]:
         for page in self.__iter_page(
             params=params,
             client=client,
             limit=limit,
             raw_data=False,
+            datalayer=datalayer,
         ):
             for item in page.get("items", []):
                 if map_model:
@@ -379,12 +430,13 @@ class PaginationMixin(BaseMixin, Generic[T]):
 
 
 class ListMixin(BaseMixin, Generic[T]):
-    def all(self, params=None, client=None) -> list[T]:
+    def all(self, params=None, client=None, datalayer=False) -> list[T]:
         if not client:
             client = ChiftClient()
         client.consumer_id = self.consumer_id
         client.connection_id = self.connection_id
         client.raw_data = False
+        client.datalayer = datalayer
         client.client_request_id = None
 
         json_data = client.get_all(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chift"
-version = "0.6.6"
+version = "0.6.7"
 description = "Chift API client"
 authors = ["Henry Hertoghe <henry.hertoghe@chift.eu>"]
 readme = "README.md"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,57 @@
+import http.client as httplib
+
 import pytest
 
 from chift.api.client import ChiftClient
 from chift.openapi.models import Consumer
 from tests.fixtures import client
+
+
+class _FakeResponse:
+    status_code = httplib.OK
+
+    def json(self):
+        return {"ok": True}
+
+
+def _capture_headers(monkeypatch):
+    """Patch process_request to capture the headers of the next request."""
+    captured = {}
+
+    def fake_process_request(self, request_type, url_path, headers=None, **kw):
+        captured.update(headers or {})
+        return _FakeResponse()
+
+    monkeypatch.setattr(ChiftClient, "process_request", fake_process_request)
+    return captured
+
+
+def _build_client(chift):
+    return ChiftClient(
+        client_id=chift.client_id,
+        client_secret=chift.client_secret,
+        account_id=chift.account_id,
+        url_base=chift.url_base,
+    )
+
+
+def test_datalayer_header_sent(chift, monkeypatch):
+    captured = _capture_headers(monkeypatch)
+    chift_client = _build_client(chift)
+    chift_client.datalayer = True
+
+    chift_client.get("/some/path")
+
+    assert captured.get("x-chift-datalayer") == "true"
+
+
+def test_datalayer_header_absent_by_default(chift, monkeypatch):
+    captured = _capture_headers(monkeypatch)
+    chift_client = _build_client(chift)
+
+    chift_client.get("/some/path")
+
+    assert "x-chift-datalayer" not in captured
 
 
 @pytest.mark.mock_chift_response(client.CONSUMER_ALL, client.CONSUMER_ALL[0])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,16 @@ def test_datalayer_header_sent(chift, monkeypatch):
     assert captured.get("x-chift-datalayer") == "true"
 
 
+def test_datalayer_header_if_available(chift, monkeypatch):
+    captured = _capture_headers(monkeypatch)
+    chift_client = _build_client(chift)
+    chift_client.datalayer = "if_available"
+
+    chift_client.get("/some/path")
+
+    assert captured.get("x-chift-datalayer") == "if_available"
+
+
 def test_datalayer_header_absent_by_default(chift, monkeypatch):
     captured = _capture_headers(monkeypatch)
     chift_client = _build_client(chift)


### PR DESCRIPTION
## What

Adds support for the datalayer, mirroring how other `x-chift-*` headers are handled.

A new optional `datalayer` parameter is available on the request mixin methods (`get`, `all`, `iter_all`, `create`, `update`, `delete`). It maps to the `x-chift-datalayer` request header and supports both modes the backend now accepts ([backbone-python #4147](https://github.com/chift-oneapi/backbone-python/pull/4147)):

| `datalayer` value | header sent | behaviour |
|---|---|---|
| `False` (default) | *(omitted)* | live connector ("classic" mode), as before |
| `True` | `x-chift-datalayer: true` | require the datalayer, error when it can't serve the request |
| `"if_available"` | `x-chift-datalayer: if_available` | use the datalayer when available, otherwise fall back to classic mode |

```python
# require the datalayer
consumer.accounting.Invoice.all(datalayer=True)

# use the datalayer if available, else serve live
invoice = consumer.accounting.Invoice.get(invoice_id, datalayer="if_available")
```

## How

Follows the existing `raw_data` → `x-chift-raw-data` pattern:
- Added a `DatalayerMode = Union[bool, Literal["if_available"]]` type alias in `client.py`.
- `ChiftClient` gains a `datalayer` attribute; `make_request` emits `x-chift-datalayer` (value `"true"` for `True`, or the string verbatim for `"if_available"`) when set, and resets it in the `finally` block like `raw_data`/`client_request_id`.
- Each mixin method accepts `datalayer: DatalayerMode = False` and assigns it to the client before the call. Type `@overload`s updated accordingly.
- The `create` pagination loop re-applies `datalayer` on subsequent pages (the header is reset after each request).

## Tests

- Added `tests/test_client.py` cases: header sent as `"true"` for `datalayer=True`, `"if_available"` for that mode, and absent by default.
- Full suite green (61 passed, 13 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)