### PR TITLE
fix: resolve create path for classmethod managers (Consumer.create)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.8 - 2026-07-15
+- fix: `Consumer.create()` (and other classmethod managers) no longer raise `AttributeError: 'Consumer' has no attribute 'chift_model_create'`; `CreateMixin.create` resolves the create path with a fallback to `chift_model`
+
 ## 0.6.7 - 2026-07-10
 - client: add `datalayer` parameter on request methods to send the `x-chift-datalayer` header. Supports both modes: `datalayer=True` (`"true"`) and `datalayer="if_available"`
 

--- a/chift/api/mixins.py
+++ b/chift/api/mixins.py
@@ -183,7 +183,9 @@ class CreateMixin(BaseMixin, Generic[T]):
         # Resolve the create path with the same fallback as BaseMixin.__init__ so create() also
         # works when invoked through a classmethod manager (e.g. Consumer.create), where __init__
         # has not run and chift_model_create is therefore unset on the class.
-        chift_model_create = getattr(self, "chift_model_create", None) or self.chift_model
+        chift_model_create = (
+            getattr(self, "chift_model_create", None) or self.chift_model
+        )
 
         json_data = client.post_one(
             self.chift_vertical,

--- a/chift/api/mixins.py
+++ b/chift/api/mixins.py
@@ -180,9 +180,14 @@ class CreateMixin(BaseMixin, Generic[T]):
         client.datalayer = datalayer
         client.client_request_id = client_request_id
 
+        # Resolve the create path with the same fallback as BaseMixin.__init__ so create() also
+        # works when invoked through a classmethod manager (e.g. Consumer.create), where __init__
+        # has not run and chift_model_create is therefore unset on the class.
+        chift_model_create = getattr(self, "chift_model_create", None) or self.chift_model
+
         json_data = client.post_one(
             self.chift_vertical,
-            self.chift_model_create,
+            chift_model_create,
             data,
             extra_path=self.extra_path,
             params=params,
@@ -217,7 +222,7 @@ class CreateMixin(BaseMixin, Generic[T]):
                     client.datalayer = datalayer
                     json_data = client.post_one(
                         self.chift_vertical,
-                        self.chift_model_create,
+                        chift_model_create,
                         data,
                         extra_path=self.extra_path,
                         params={"page": page, "size": size} | params,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chift"
-version = "0.6.7"
+version = "0.6.8"
 description = "Chift API client"
 authors = ["Henry Hertoghe <henry.hertoghe@chift.eu>"]
 readme = "README.md"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,3 +84,23 @@ def test_client_consumer_id(chift):
     assert consumer
 
     assert consumer.invoicing.Invoice.consumer_id == consumer.consumerid
+
+
+def test_consumer_create_classmethod_resolves_create_path(chift, monkeypatch):
+    # Regression: Consumer.create() is a classmethod, so CreateMixin.create must resolve the
+    # create path without relying on BaseMixin.__init__ having set chift_model_create.
+    captured = {}
+
+    def fake_post_one(self, vertical, model, data, extra_path=None, params=None):
+        captured["vertical"] = vertical
+        captured["model"] = model
+        return {"consumerid": "00000000-0000-0000-0000-000000000001", **data}
+
+    monkeypatch.setattr(ChiftClient, "post_one", fake_post_one)
+    chift_client = _build_client(chift)
+
+    consumer = chift.Consumer.create({"name": "Acme"}, client=chift_client)
+
+    assert captured["vertical"] == "consumers"
+    assert captured["model"] is None
+    assert consumer.name == "Acme"


### PR DESCRIPTION
## Problem

`chift.Consumer.create({...})` raises:

```
AttributeError: type object 'Consumer' has no attribute 'chift_model_create'
```

`Consumer` exposes `create()` as a **classmethod** (like `get()`/`all()`), which delegates to `CreateMixin.create`. But `CreateMixin.create` reads `self.chift_model_create`, and that attribute is only ever set in `BaseMixin.__init__`. Classmethod managers never instantiate, so the attribute is missing on the class → `AttributeError`.

`get()` / `all()` are unaffected because they only read `chift_vertical` / `chift_model` (both class attributes).

## Fix

Resolve the create path inside `CreateMixin.create` with the same fallback `BaseMixin.__init__` already uses:

```python
chift_model_create = getattr(self, "chift_model_create", None) or self.chift_model
```

- **Instance callers**: unchanged — `getattr` returns the value `__init__` set.
- **Classmethod managers** (e.g. `Consumer.create`): now resolves to `chift_model` (correct) instead of raising.

## Test

Adds `test_consumer_create_classmethod_resolves_create_path` verifying `Consumer.create()` posts to the `consumers` vertical and returns the mapped model. `tests/test_client.py` passes (5 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)